### PR TITLE
val3_driver: add motion streaming i'face launch files

### DIFF
--- a/staubli_val3_driver/launch/motion_streaming_interface.launch
+++ b/staubli_val3_driver/launch/motion_streaming_interface.launch
@@ -1,0 +1,14 @@
+<!--
+  Wrapper launch file for the Staubli specific motion streaming interface node.
+-->
+<launch>
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" />
+
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+  <!-- reuse generic industrial robot client interface streaming node -->
+  <node pkg="industrial_robot_client" type="motion_streaming_interface"
+    name="motion_streaming_interface" />
+</launch>

--- a/staubli_val3_driver/launch/robot_interface_streaming.launch
+++ b/staubli_val3_driver/launch/robot_interface_streaming.launch
@@ -1,0 +1,44 @@
+<launch>
+
+<!-- This launch file provides a socket-based connection to industrial robots
+     that implement the standard ROS Industrial simple_message protocol.
+     *** Motion control is implemented by STREAMING path data to the robot ***
+         (for DOWNLOAD-based path-control, use a different launch file)
+
+     Several nodes are started, to supply both low-level robot communication
+     and higher-level actionlib support:
+       - robot_state : publishes current joint positions and robot state data
+       - motion_streaming_interface : command robot motion by sending motion points to robot
+       - joint_trajectory_action : actionlib interface to control robot motion
+
+  Usage:
+    robot_interface_streaming.launch robot_ip:=<value>
+-->
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" />
+
+  <!-- copy the specified parameters to the Parameter Server, for
+       use by nodes below -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+  <!-- robot_state: publishes joint positions and robot-state data
+       (from socket connection to robot)
+  -->
+  <include file="$(find staubli_val3_driver)/launch/robot_state.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+
+  <!-- motion_streaming_interface: sends robot motion commands by
+       STREAMING path to robot (using socket connection to robot)
+  -->
+  <include file="$(find staubli_val3_driver)/launch/motion_streaming_interface.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+  </include>
+
+  <!-- joint_trajectory_action: provides actionlib interface for
+       high-level robot control
+  -->
+  <node pkg="industrial_robot_client" type="joint_trajectory_action"
+    name="joint_trajectory_action" />
+</launch>

--- a/staubli_val3_driver/launch/robot_state.launch
+++ b/staubli_val3_driver/launch/robot_state.launch
@@ -1,0 +1,13 @@
+<!--
+  Wrapper launch file for the Staubli specific robot_state node.
+-->
+<launch>
+  <!-- IP of robot (or PC running simulation) -->
+  <arg name="robot_ip" />
+
+  <!-- put them on the parameter server -->
+  <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+
+  <!-- reuse generic industrial robot client state node -->
+  <node pkg="industrial_robot_client" type="robot_state" name="robot_state" />
+</launch>


### PR DESCRIPTION
This adds the 'standard' set of launch files to the `val3_driver` package.

Users need only
```
roslaunch staubli_val3_driver motion_streaming_interface.launch robot_ip:=1.2.3.4
```

for stand-alone use or `include` the same file in a robot specific launch file.

`robot_interface_streaming.launch` and `robot_state.launch` may be started individually to start only the trajectory relay or the state reporting side of the driver (for state display launch files fi).
